### PR TITLE
Add support for new "app" subdomain

### DIFF
--- a/Memrise_All_Typing.user.js
+++ b/Memrise_All_Typing.user.js
@@ -8,7 +8,7 @@
 // @match          https://app.memrise.com/garden/review/*
 // @match          https://decks.memrise.com/course/*/garden/*
 // @match          https://decks.memrise.com/garden/review/*
-// @version        0.2.0
+// @version        0.2.1
 // @updateURL      https://github.com/cooljingle/memrise-all-typing/raw/master/Memrise_All_Typing.user.js
 // @downloadURL    https://github.com/cooljingle/memrise-all-typing/raw/master/Memrise_All_Typing.user.js
 // @grant          none

--- a/Memrise_All_Typing.user.js
+++ b/Memrise_All_Typing.user.js
@@ -4,6 +4,8 @@
 // @description    All typing / no multiple choice when doing Memrise typing courses
 // @match          https://www.memrise.com/course/*/garden/*
 // @match          https://www.memrise.com/garden/review/*
+// @match          https://app.memrise.com/course/*/garden/*
+// @match          https://app.memrise.com/garden/review/*
 // @match          https://decks.memrise.com/course/*/garden/*
 // @match          https://decks.memrise.com/garden/review/*
 // @version        0.2.0


### PR DESCRIPTION
Memrise seems to now be serving pages under "app.memrise.com" instead of the former "www.memrise.com". This change adds matches for this new URL and increments the version number.