### PR TITLE
Support new address app.memrise.com

### DIFF
--- a/Memrise_All_Typing.user.js
+++ b/Memrise_All_Typing.user.js
@@ -3,7 +3,9 @@
 // @namespace      https://github.com/cooljingle
 // @description    All typing / no multiple choice when doing Memrise typing courses
 // @match          https://www.memrise.com/course/*/garden/*
+// @match          https://app.memrise.com/course/*/garden/*
 // @match          https://www.memrise.com/garden/review/*
+// @match          https://app.memrise.com/garden/review/*
 // @match          https://decks.memrise.com/course/*/garden/*
 // @match          https://decks.memrise.com/garden/review/*
 // @version        0.2.0


### PR DESCRIPTION
Memrise seems to have changed the addresses of their lessons from `https://www.memrise.com/course/*/garden/*` to `https://app.memrise.com/course/*/garden/*` , and the same for review (changing `www` to `app`). This means the script is not called anymore. This change, which simply adds `@match` statements with the new addresses, worked for me. Please make sure I did this correctly in Github.
Thank you for the work!